### PR TITLE
MAE-230: Set default manual direct debit configurations

### DIFF
--- a/CRM/Membershipextrasdata/Upgrader.php
+++ b/CRM/Membershipextrasdata/Upgrader.php
@@ -41,6 +41,7 @@ class CRM_Membershipextrasdata_Upgrader extends CRM_Membershipextrasdata_Upgrade
     $this->createPriceSetsAndFields();
     $this->createDiscountCodes();
     $this->createTestingWebforms();
+    $this->setDefaultManualDirectDebitConfigurations();
   }
 
   /**
@@ -358,6 +359,22 @@ class CRM_Membershipextrasdata_Upgrader extends CRM_Membershipextrasdata_Upgrade
       $wf_me_discount_settings = new wf_me_discount_settings();
       $wf_me_discount_settings->save($webformsNid, 1);
     }
+  }
+
+  /**
+   * Set default manual direct debit configurations
+   */
+  private function setDefaultManualDirectDebitConfigurations() {
+    $configFields = [
+      'manualdirectdebit_default_reference_prefix' => 'DD',
+      'manualdirectdebit_minimum_reference_prefix_length' => 6,
+      'manualdirectdebit_new_instruction_run_dates' => [1],
+      'manualdirectdebit_payment_collection_run_dates' => [1],
+      'manualdirectdebit_minimum_days_to_first_payment' => 2,
+      'manualdirectdebit_days_in_advance_for_collection_reminder' => 3,
+      'manualdirectdebit_batch_submission_queue_limit' => 50,
+    ];
+    Civi::settings()->add($configFields);
   }
 
 }

--- a/WebformExport/s22.drupal
+++ b/WebformExport/s22.drupal
@@ -1095,7 +1095,7 @@ array(
               'contribution' => array(
                 1 => array(
                   'contribution_page_id' => '1',
-                  'payment_processor_id' => '1',
+                  'payment_processor_id' => '3',
                   'honor_type_id' => '1',
                   'is_test' => '0',
                   'frequency_unit' => 'year',


### PR DESCRIPTION
## Overview
This PR will create default and sensible configurations for `uk.co.compucorp.manualdirectdebit` extension.

## Before
![Screenshot from 2021-02-03 16-33-27](https://user-images.githubusercontent.com/74309109/106761518-92fca080-663d-11eb-834a-7b04beea931b.png)

## After
![Screenshot from 2021-02-03 16-31-42](https://user-images.githubusercontent.com/74309109/106761298-5af55d80-663d-11eb-82ae-befd64ffd463.png)